### PR TITLE
feat(log): never overwrite an existing log file (auto-rename)

### DIFF
--- a/library/a8/src/log.c
+++ b/library/a8/src/log.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <errno.h>
 #include <sys/mman.h>
 #include <stdint.h>
 #include "pru.h"
@@ -147,7 +148,34 @@ log_t* LogInit(const pru_mem_t* pru_mem) {
 }
 
 int LogNewFile(log_t* log, char* file) {
-  log->fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+  // Never overwrite an existing log. Open with O_EXCL; on a name clash insert
+  // "-1", "-2", ... before the extension until a free name is found. O_EXCL makes
+  // the create atomic (no TOCTOU race), so no data is ever silently clobbered.
+  char actual[600];
+  snprintf(actual, sizeof(actual), "%s", file);
+  log->fd = open(actual, O_WRONLY | O_CREAT | O_EXCL, 0666);
+  if (log->fd < 0 && errno == EEXIST) {
+    char base[512], ext[64];
+    const char* dot   = strrchr(file, '.');
+    const char* slash = strrchr(file, '/');
+    if (dot && (!slash || dot > slash)) {         // a real extension (dot after last '/')
+      size_t bl = (size_t)(dot - file);
+      if (bl >= sizeof(base)) bl = sizeof(base) - 1;
+      memcpy(base, file, bl);
+      base[bl] = '\0';
+      snprintf(ext, sizeof(ext), "%s", dot);
+    } else {
+      snprintf(base, sizeof(base), "%s", file);
+      ext[0] = '\0';
+    }
+    for (int i = 1; i < 100000 && log->fd < 0; i++) {
+      snprintf(actual, sizeof(actual), "%s-%d%s", base, i, ext);
+      log->fd = open(actual, O_WRONLY | O_CREAT | O_EXCL, 0666);
+      if (log->fd < 0 && errno != EEXIST) break;  // a real error, not a clash
+    }
+    if (log->fd >= 0)
+      printf("Log file %s exists; not overwriting -- saving to %s instead.\n", file, actual);
+  }
   if (log->fd < 0) {
     printf("Error opening log file %s\n", file);
     return -1;


### PR DESCRIPTION
`LogNewFile` now opens the log with `O_EXCL` instead of `O_TRUNC`. On a name
clash it inserts `-1`, `-2`, … before the extension until a free name is found
(atomic via `O_EXCL`, so no TOCTOU race) and prints the name actually used. No
existing log is ever silently clobbered, with **no caller changes** — a global
safety net for every app.

Same change is already on `lab` (`2eb87e1`) and being applied to `am64x`
(where the file lives at `library/a72/src/log.c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)